### PR TITLE
Interactive Test Walking 

### DIFF
--- a/test/TESTING.org
+++ b/test/TESTING.org
@@ -6,11 +6,30 @@ WarrenBuf uses a native browser-based test suite with no dependencies on Jest or
 
 Open ~test.html~ in your browser. Tests run automatically on page load.
 
+* Interactive Walkthrough
+
+Each test includes a *Walkthrough* button that opens an interactive step-by-step debugger:
+
+- *Left panel*: Test source code with inline step markers and expect highlighting
+- *Right panel*: Live WarrenBuf editor showing the test execution
+- *Step navigation*: Previous/Next buttons to replay test actions one at a time
+
+** How it works
+
+1. Click the "Walkthrough" button on any test
+2. Use Next/Previous buttons to step through the test execution
+3. Watch the editor state update in real-time on the right panel
+4. Expect statements are highlighted green (✓) or red (✗) as you step past them
+5. Step markers (1, 2, 3...) show which walkthrough step maps to which code line
+
+The walkthrough replays the exact same actions recorded during the test run, providing a visual debugging experience.
+
 * Directory Structure
 
-- *test.html* - Test runner UI with results display
+- *test.html* - Test runner UI with results display and interactive walkthrough panel
 - *test-framework.js* - Domain-agnostic test library with ~describe~, ~it~, ~xit~, ~expect~
-- *dsl.js* - Fixture to (1) isolate test state and (2) literate DSL for user actions. 
+- *dsl.js* - Test harness providing (1) literate DSL for user actions and (2) step recording for walkthrough replay
+- *expect.js* - Assertion matchers with special support for EditorTestHarness
 - *test.spec.js* - All test definitions
 
 * Writing Tests
@@ -22,7 +41,7 @@ runner.describe('Feature Name', () => {
   let fixture;
 
   runner.beforeEach(() => {
-    fixture = new EditorFixture();
+    fixture = new EditorTestHarness();
   });
 
   runner.it('should do something', () => {
@@ -36,15 +55,21 @@ runner.describe('Feature Name', () => {
 
 ** Test Isolation
 
-Each test gets a *fresh DOM node and WarrenBuf instance* via ~new EditorFixture()~. This ensures proper test isolation with no state leakage between tests.
+Each test gets a *fresh DOM node and WarrenBuf instance* via ~new EditorTestHarness()~. This ensures proper test isolation with no state leakage between tests.
 
-** EditorFixture & Literate DSL
+** EditorTestHarness & Literate DSL
 
-The test fixture provides a literate, chainable DSL that reads like user actions:
+The test harness serves three purposes:
+
+1. *Test isolation* - Provides an isolated editor instance (DOM node + WarrenBuf) for each test
+2. *Test execution* - Drives the editor with a literate DSL for user actions
+3. *Step recording* - Captures all actions as metadata for interactive walkthrough replay
+
+The harness provides a literate, chainable DSL that reads like user actions:
 
 #+begin_src javascript
-// Create fixture
-const fixture = new EditorFixture();
+// Create harness
+const fixture = new EditorTestHarness();
 
 // Access WarrenBuf instance and DOM node
 fixture.wb    // WarrenBuf instance
@@ -61,6 +86,8 @@ fixture.press(Key.ArrowRight).withShiftKey().once();
 fixture.press(Key.ArrowDown).withShiftKey().withMetaKey().once();
 fixture.press(' ').once();  // Single character key
 #+end_src
+
+All actions are automatically recorded to ~fixture.steps~ as metadata, enabling step-by-step replay in the interactive walkthrough UI.
 
 ** Available Key Constants
 

--- a/test/dsl.js
+++ b/test/dsl.js
@@ -40,6 +40,36 @@ const Key = {
 const VALID_KEYS = new Set(Object.values(Key));
 
 /**
+ * Helper to create a new DOM node for EditorFixture
+ */
+function createEditorNode() {
+  const container = document.querySelector('.editor-container');
+  const node = document.createElement('div');
+  node.className = 'wb no-select';
+  node.innerHTML = `
+    <textarea class="wb-clipboard-bridge" aria-hidden="true"></textarea>
+    <div style="display: flex">
+      <div class="wb-gutter"></div>
+      <div class="wb-lines" style="flex: 1; overflow: hidden;"></div>
+    </div>
+    <div class="wb-status" style="display: flex; justify-content: space-between;">
+      <div class="wb-status-left" style="display: flex;">
+        <span class="wb-linecount"></span>
+      </div>
+      <div class="wb-status-right" style="display: flex;">
+        <span class="wb-coordinate"></span>
+        <span>|</span>
+        <span class="wb-indentation"></span>
+      </div>
+    </div>
+  `;
+
+  container.innerHTML = '';
+  container.appendChild(node);
+  return node;
+}
+
+/**
  * Test environment for a single editor instance.
  * Provides literate methods for user interactions.
  *
@@ -163,3 +193,9 @@ class EditorFixture {
     }
   }
 }
+
+// EditorFixture factory
+const FixtureFactory = {
+  forTest: () => new EditorFixture(createEditorNode()),
+  forWalkthrough: (node) => new EditorFixture(node)
+};

--- a/test/dsl.js
+++ b/test/dsl.js
@@ -79,34 +79,10 @@ class EditorTestHarness {
   constructor(node) {
     this.node = node;
     this.wb = new WarrenBuf(node, null, null, 10);
-    this.steps = []; // Record all steps for walkthrough
+    this.walkthrough = new Walkthrough();
 
     // Store reference for test framework
     window.currentTestFixture = this;
-  }
-
-  _recordStep(description, metadata) {
-    this.steps.push({
-      description,
-      metadata  // Store operation details, not closures
-    });
-  }
-
-  // Replay a step on this fixture (used for walkthrough)
-  replayStep(stepIndex) {
-    const step = this.steps[stepIndex];
-    const meta = step.metadata;
-
-    if (meta.type === 'type') {
-      for (const char of meta.text) {
-        dispatchKey(this.node, char);
-      }
-    } else if (meta.type === 'press') {
-      const count = meta.count || 1;
-      for (let i = 0; i < count; i++) {
-        dispatchKey(this.node, meta.key, meta.modifiers);
-      }
-    }
   }
 
   /**
@@ -146,7 +122,7 @@ class EditorTestHarness {
       once() {
         const modStr = Object.keys(this._modifiers).filter(k => this._modifiers[k]).join('+');
         const desc = modStr ? `press(${modStr}+${this._key})` : `press(${this._key})`;
-        fixture._recordStep(desc, {
+        fixture.walkthrough.recordStep(desc, {
           type: 'press',
           key: this._key,
           modifiers: { ...this._modifiers },
@@ -159,7 +135,7 @@ class EditorTestHarness {
       times(count) {
         const modStr = Object.keys(this._modifiers).filter(k => this._modifiers[k]).join('+');
         const desc = modStr ? `press(${modStr}+${this._key}).times(${count})` : `press(${this._key}).times(${count})`;
-        fixture._recordStep(desc, {
+        fixture.walkthrough.recordStep(desc, {
           type: 'press',
           key: this._key,
           modifiers: { ...this._modifiers },
@@ -184,7 +160,7 @@ class EditorTestHarness {
    *   editor.type('Hello World');
    */
   type(text) {
-    this._recordStep(`type('${text}')`, {
+    this.walkthrough.recordStep(`type('${text}')`, {
       type: 'type',
       text: text
     });

--- a/test/dsl.js
+++ b/test/dsl.js
@@ -40,7 +40,7 @@ const Key = {
 const VALID_KEYS = new Set(Object.values(Key));
 
 /**
- * Helper to create a new DOM node for EditorFixture
+ * Helper to create a new DOM node for EditorTestHarness
  */
 function createEditorNode() {
   const container = document.querySelector('.editor-container');
@@ -75,7 +75,7 @@ function createEditorNode() {
  *
  * @param {HTMLElement} node - Required DOM node to attach to
  */
-class EditorFixture {
+class EditorTestHarness {
   constructor(node) {
     this.node = node;
     this.wb = new WarrenBuf(node, null, null, 10);
@@ -194,8 +194,8 @@ class EditorFixture {
   }
 }
 
-// EditorFixture factory
+// EditorTestHarness factory
 const FixtureFactory = {
-  forTest: () => new EditorFixture(createEditorNode()),
-  forWalkthrough: (node) => new EditorFixture(node)
+  forTest: () => new EditorTestHarness(createEditorNode()),
+  forWalkthrough: (node) => new EditorTestHarness(node)
 };

--- a/test/dsl.js
+++ b/test/dsl.js
@@ -43,50 +43,16 @@ const VALID_KEYS = new Set(Object.values(Key));
  * Test environment for a single editor instance.
  * Provides literate methods for user interactions.
  *
- * @param {HTMLElement} [existingNode] - Optional DOM node to attach to. If not provided, creates new node in .editor-container
+ * @param {HTMLElement} node - Required DOM node to attach to
  */
 class EditorFixture {
-  constructor(existingNode = null) {
-    let node;
-
-    if (existingNode) {
-      // Use provided node (for walkthrough panel)
-      node = existingNode;
-    } else {
-      // Create new node in hidden container (for tests)
-      const container = document.querySelector('.editor-container');
-      node = document.createElement('div');
-      node.className = 'wb no-select';
-      node.innerHTML = `
-        <textarea class="wb-clipboard-bridge" aria-hidden="true"></textarea>
-        <div style="display: flex">
-          <div class="wb-gutter"></div>
-          <div class="wb-lines" style="flex: 1; overflow: hidden;"></div>
-        </div>
-        <div class="wb-status" style="display: flex; justify-content: space-between;">
-          <div class="wb-status-left" style="display: flex;">
-            <span class="wb-linecount"></span>
-          </div>
-          <div class="wb-status-right" style="display: flex;">
-            <span class="wb-coordinate"></span>
-            <span>|</span>
-            <span class="wb-indentation"></span>
-          </div>
-        </div>
-      `;
-
-      container.innerHTML = '';
-      container.appendChild(node);
-    }
-
+  constructor(node) {
     this.node = node;
     this.wb = new WarrenBuf(node, null, null, 10);
     this.steps = []; // Record all steps for walkthrough
 
-    // Store reference for test framework (only for test runs, not walkthrough)
-    if (!existingNode) {
-      window.currentTestFixture = this;
-    }
+    // Store reference for test framework
+    window.currentTestFixture = this;
   }
 
   _recordStep(description, metadata) {

--- a/test/dsl.js
+++ b/test/dsl.js
@@ -80,7 +80,7 @@ class EditorFixture {
     }
 
     this.node = node;
-    this.wb = new WarrenBuf(node);
+    this.wb = new WarrenBuf(node, null, null, 10);
     this.steps = []; // Record all steps for walkthrough
 
     // Store reference for test framework (only for test runs, not walkthrough)

--- a/test/expect.js
+++ b/test/expect.js
@@ -1,8 +1,8 @@
 // Assertion library for WarrenBuf tests
 
 function expect(actual) {
-  // Check if actual is an EditorFixture instance
-  if (typeof EditorFixture !== 'undefined' && actual instanceof EditorFixture) {
+  // Check if actual is an EditorTestHarness instance
+  if (typeof EditorTestHarness !== 'undefined' && actual instanceof EditorTestHarness) {
     return {
       toHaveLines(...expectedLines) {
         if (actual.wb.Model.lines.length !== expectedLines.length) {

--- a/test/test-framework.js
+++ b/test/test-framework.js
@@ -15,7 +15,13 @@ class TestRunner {
 
   it(name, fn, description = '') {
     if (!this.currentSuite) throw new Error('it() must be called inside describe()');
-    this.currentSuite.tests.push({ name, fn, description, status: 'pending' });
+    this.currentSuite.tests.push({
+      name,
+      fn,
+      fnSource: fn.toString(), // Save source code for walkthrough
+      description,
+      status: 'pending'
+    });
   }
 
   xit(name, fn, description = '') {
@@ -48,10 +54,14 @@ class TestRunner {
           await test.fn();
 
           test.status = 'pass';
+          // Capture fixture from global (set by EditorFixture constructor)
+          test.fixture = window.currentTestFixture;
           results.passed++;
         } catch (error) {
           test.status = 'fail';
           test.error = error;
+          // Capture fixture even on failure for debugging
+          test.fixture = window.currentTestFixture;
           results.failed++;
         }
 

--- a/test/test-framework.js
+++ b/test/test-framework.js
@@ -97,7 +97,7 @@ class TestRunner {
             results.passed++;
           }
 
-          // Capture fixture and expect results from global (set by EditorFixture constructor)
+          // Capture fixture and expect results from global (set by EditorTestHarness constructor)
           test.fixture = window.currentTestFixture;
           test.expectResults = expectResults;
         } catch (error) {

--- a/test/test-framework.js
+++ b/test/test-framework.js
@@ -100,9 +100,6 @@ class TestRunner {
           // Capture fixture and expect results from global (set by EditorFixture constructor)
           test.fixture = window.currentTestFixture;
           test.expectResults = expectResults;
-          const numSuccess = expectResults.filter(r => r.success).length;
-          const numFailed = expectResults.filter(r => !r.success).length;
-          console.log(`Test "${test.name}" completed. Successful: ${numSuccess}, Failed: ${numFailed}`);
         } catch (error) {
           // Restore original expect
           window.expect = originalExpect;
@@ -112,9 +109,6 @@ class TestRunner {
           // Capture fixture and expect results even on failure for debugging
           test.fixture = window.currentTestFixture;
           test.expectResults = expectResults;
-          const numSuccess = expectResults.filter(r => r.success).length;
-          const numFailed = expectResults.filter(r => !r.success).length;
-          console.log(`Test "${test.name}" failed. Successful: ${numSuccess}, Failed: ${numFailed}`, firstError);
           results.failed++;
         }
 

--- a/test/test.html
+++ b/test/test.html
@@ -621,35 +621,15 @@
       console.log('Success lines:', Array.from(successLineIndices));
       console.log('Failure lines:', Array.from(failureLineIndices));
 
-      // Render source with step markers and error highlighting
-      const codeHtml = sourceLines.map((line, lineIndex) => {
-        const stepNum = lineToStep.get(lineIndex);
-        const isStepLine = stepNum !== undefined;
-        const isFailureLine = failureLineIndices.has(lineIndex);
-        const isSuccessLine = successLineIndices.has(lineIndex);
+      // Store expect data for progressive revealing
+      currentWalkthrough.expectData = {
+        successLineIndices,
+        failureLineIndices,
+        lineToStep
+      };
 
-        let classes = 'code-line';
-        if (isFailureLine) classes += ' error-line';
-        if (isSuccessLine && !isFailureLine) classes += ' success-line';
-        if (isStepLine) classes += ' step-line';
-
-        const onclick = isStepLine ? `onclick="jumpToStep(${stepNum})"` : '';
-
-        // Show markers
-        let marker = '';
-        if (isStepLine) {
-          marker += `<span class="step-marker">${stepNum + 1}</span>`;
-        }
-        if (isFailureLine) {
-          marker += `<span class="error-marker">✗</span>`;
-        } else if (isSuccessLine) {
-          marker += `<span class="success-marker">✓</span>`;
-        }
-
-        return `<div class="${classes}" data-step="${stepNum ?? ''}" ${onclick}>${marker}${escapeHtml(line)}</div>`;
-      }).join('');
-
-      codeView.innerHTML = codeHtml;
+      // Render source with step markers (expects hidden initially)
+      renderWalkthroughCode();
 
       // Debug: log expect detection
       console.log('Test:', test.name, 'Status:', test.status);
@@ -711,6 +691,61 @@
       currentWalkthrough = null;
       currentStep = 0;
       walkthroughEditor = null;
+    }
+
+    function renderWalkthroughCode() {
+      if (!currentWalkthrough) return;
+
+      const test = currentWalkthrough;
+      const { successLineIndices, failureLineIndices, lineToStep } = test.expectData || {};
+      if (!lineToStep) return;
+
+      const codeView = document.getElementById('walkthrough-code');
+      const sourceLines = test.fnSource.split('\n');
+
+      // Determine which expects should be revealed based on current step
+      // An expect is revealed if it comes before or at the current step position
+      let maxRevealedLine = -1;
+      if (currentStep > 0) {
+        // Find the line number of the last executed step
+        for (const [lineIdx, stepNum] of lineToStep.entries()) {
+          if (stepNum < currentStep) {
+            maxRevealedLine = Math.max(maxRevealedLine, lineIdx);
+          }
+        }
+      }
+
+      const codeHtml = sourceLines.map((line, lineIndex) => {
+        const stepNum = lineToStep.get(lineIndex);
+        const isStepLine = stepNum !== undefined;
+        const isFailureLine = failureLineIndices?.has(lineIndex);
+        const isSuccessLine = successLineIndices?.has(lineIndex);
+
+        // Only show expect highlighting if we've passed this line in the walkthrough
+        const shouldRevealExpect = lineIndex <= maxRevealedLine;
+
+        let classes = 'code-line';
+        if (isFailureLine && shouldRevealExpect) classes += ' error-line';
+        if (isSuccessLine && !isFailureLine && shouldRevealExpect) classes += ' success-line';
+        if (isStepLine) classes += ' step-line';
+
+        const onclick = isStepLine ? `onclick="jumpToStep(${stepNum})"` : '';
+
+        // Show markers
+        let marker = '';
+        if (isStepLine) {
+          marker += `<span class="step-marker">${stepNum + 1}</span>`;
+        }
+        if (isFailureLine && shouldRevealExpect) {
+          marker += `<span class="error-marker">✗</span>`;
+        } else if (isSuccessLine && shouldRevealExpect) {
+          marker += `<span class="success-marker">✓</span>`;
+        }
+
+        return `<div class="${classes}" data-step="${stepNum ?? ''}" ${onclick}>${marker}${escapeHtml(line)}</div>`;
+      }).join('');
+
+      codeView.innerHTML = codeHtml;
     }
 
     function stepNext() {
@@ -784,7 +819,10 @@
       document.getElementById('step-prev').disabled = currentStep === 0;
       document.getElementById('step-next').disabled = currentStep >= totalSteps;
 
-      // Update code line highlighting
+      // Re-render code view to update expect highlighting based on current step
+      renderWalkthroughCode();
+
+      // Update code line highlighting for steps (current/completed states)
       const stepLines = document.querySelectorAll('.step-line');
       stepLines.forEach((lineEl) => {
         const stepNum = parseInt(lineEl.dataset.step);

--- a/test/test.html
+++ b/test/test.html
@@ -280,6 +280,17 @@
       background: #1e3a1e;
       border-left-color: #4CAF50;
     }
+    .code-line.error-line {
+      background: #3a1e1e;
+      border-left: 3px solid #f44336;
+      padding-left: 5px;
+    }
+    .error-marker {
+      display: inline-block;
+      margin-right: 8px;
+      color: #f44336;
+      font-weight: bold;
+    }
     .step-marker {
       display: inline-block;
       width: 25px;
@@ -530,13 +541,47 @@
         }
       });
 
-      // Render source with step markers
+      // Find error line if test failed
+      let errorLineIndex = -1;
+      if (test.status === 'fail' && test.error && test.error.stack) {
+        // Try to extract line number from error stack
+        // Look for patterns like "at <anonymous>:5:10" or similar
+        const stackLines = test.error.stack.split('\n');
+        for (const stackLine of stackLines) {
+          // Match patterns like ":lineNum:" in the stack trace
+          const match = stackLine.match(/:(\d+):/);
+          if (match) {
+            const absoluteLine = parseInt(match[1]);
+            // The line numbers in stack traces are 1-based and refer to the function body
+            // We need to map this to our source line index
+            errorLineIndex = absoluteLine - 2; // Adjust for function wrapper
+            break;
+          }
+        }
+
+        // Fallback: look for expect() calls that might have failed
+        if (errorLineIndex === -1 || errorLineIndex < 0 || errorLineIndex >= sourceLines.length) {
+          sourceLines.forEach((line, idx) => {
+            if (line.includes('expect(') && errorLineIndex === -1) {
+              errorLineIndex = idx;
+            }
+          });
+        }
+      }
+
+      // Render source with step markers and error highlighting
       const codeHtml = sourceLines.map((line, lineIndex) => {
         const stepNum = lineToStep.get(lineIndex);
         const isStepLine = stepNum !== undefined;
-        const classes = isStepLine ? 'code-line step-line' : 'code-line';
+        const isErrorLine = lineIndex === errorLineIndex;
+
+        let classes = 'code-line';
+        if (isErrorLine) classes += ' error-line';
+        if (isStepLine) classes += ' step-line';
+
         const onclick = isStepLine ? `onclick="jumpToStep(${stepNum})"` : '';
-        const marker = isStepLine ? `<span class="step-marker">${stepNum + 1}</span>` : '';
+        const marker = isStepLine ? `<span class="step-marker">${stepNum + 1}</span>` :
+                       isErrorLine ? `<span class="error-marker">✗</span>` : '';
 
         return `<div class="${classes}" data-step="${stepNum ?? ''}" ${onclick}>${marker}${escapeHtml(line)}</div>`;
       }).join('');

--- a/test/test.html
+++ b/test/test.html
@@ -812,11 +812,9 @@
 
       if (currentStep === 0) {
         stepInfo.textContent = `Ready to start (${totalSteps} steps)`;
-      } else if (currentStep < totalSteps) {
+      } else if (currentStep <= totalSteps) {
         const step = currentWalkthrough.fixture.steps[currentStep - 1];
         stepInfo.textContent = `Step ${currentStep}/${totalSteps}: ${step.description}`;
-      } else {
-        stepInfo.textContent = `Complete (${totalSteps}/${totalSteps})`;
       }
 
       // Update button states

--- a/test/test.html
+++ b/test/test.html
@@ -704,7 +704,11 @@
       const sourceLines = test.fnSource.split('\n');
 
       // Determine which expects should be revealed based on current step
+      const totalSteps = currentWalkthrough.fixture.steps.length;
+      const isComplete = currentStep >= totalSteps;
+
       // An expect is revealed if it comes before or at the current step position
+      // OR if we've completed all walkthrough steps (reveal all remaining expects)
       let maxRevealedLine = -1;
       if (currentStep > 0) {
         // Find the line number of the last executed step
@@ -721,8 +725,8 @@
         const isFailureLine = failureLineIndices?.has(lineIndex);
         const isSuccessLine = successLineIndices?.has(lineIndex);
 
-        // Only show expect highlighting if we've passed this line in the walkthrough
-        const shouldRevealExpect = lineIndex <= maxRevealedLine;
+        // Show expect highlighting if we've passed this line OR completed all steps
+        const shouldRevealExpect = isComplete || lineIndex <= maxRevealedLine;
 
         let classes = 'code-line';
         if (isFailureLine && shouldRevealExpect) classes += ' error-line';

--- a/test/test.html
+++ b/test/test.html
@@ -258,6 +258,37 @@
       margin: 0;
       color: #d4d4d4;
     }
+    .code-line {
+      padding: 2px 8px;
+      line-height: 1.6;
+    }
+    .code-line.step-line {
+      cursor: pointer;
+      border-left: 3px solid transparent;
+      padding-left: 5px;
+    }
+    .code-line.step-line:hover {
+      background: #2d2d30;
+    }
+    .code-line.step-line.current {
+      background: #0e639c;
+      border-left-color: #4EC9B0;
+      color: white;
+      font-weight: bold;
+    }
+    .code-line.step-line.completed {
+      background: #1e3a1e;
+      border-left-color: #4CAF50;
+    }
+    .step-marker {
+      display: inline-block;
+      width: 25px;
+      text-align: right;
+      margin-right: 8px;
+      opacity: 0.7;
+      font-size: 11px;
+      color: #4EC9B0;
+    }
     .step-controls-panel {
       background: #2d2d30;
       padding: 12px 16px;
@@ -480,9 +511,37 @@
       document.getElementById('walkthrough-test-name').textContent = test.name;
       document.getElementById('walkthrough-test-desc').textContent = test.description || '';
 
-      // Display test code
+      // Display test code with inline step markers
       const codeView = document.getElementById('walkthrough-code');
-      codeView.innerHTML = `<pre>${escapeHtml(test.fnSource)}</pre>`;
+      const sourceLines = test.fnSource.split('\n');
+
+      // Map steps to source code lines by matching step descriptions
+      const lineToStep = new Map();
+      let stepIndex = 0;
+
+      sourceLines.forEach((line, lineIndex) => {
+        if (stepIndex < test.fixture.steps.length) {
+          const step = test.fixture.steps[stepIndex];
+          // Check if this line contains the step action (type, press, etc.)
+          if (line.includes('.type(') || line.includes('.press(')) {
+            lineToStep.set(lineIndex, stepIndex);
+            stepIndex++;
+          }
+        }
+      });
+
+      // Render source with step markers
+      const codeHtml = sourceLines.map((line, lineIndex) => {
+        const stepNum = lineToStep.get(lineIndex);
+        const isStepLine = stepNum !== undefined;
+        const classes = isStepLine ? 'code-line step-line' : 'code-line';
+        const onclick = isStepLine ? `onclick="jumpToStep(${stepNum})"` : '';
+        const marker = isStepLine ? `<span class="step-marker">${stepNum + 1}</span>` : '';
+
+        return `<div class="${classes}" data-step="${stepNum ?? ''}" ${onclick}>${marker}${escapeHtml(line)}</div>`;
+      }).join('');
+
+      codeView.innerHTML = codeHtml;
 
       // Create editor instance
       const editorNode = document.getElementById('walkthrough-editor');
@@ -597,6 +656,55 @@
       // Update button states
       document.getElementById('step-prev').disabled = currentStep === 0;
       document.getElementById('step-next').disabled = currentStep >= totalSteps;
+
+      // Update code line highlighting
+      const stepLines = document.querySelectorAll('.step-line');
+      stepLines.forEach((lineEl) => {
+        const stepNum = parseInt(lineEl.dataset.step);
+        lineEl.classList.remove('current', 'completed');
+        if (stepNum < currentStep - 1) {
+          lineEl.classList.add('completed');
+        } else if (stepNum === currentStep - 1) {
+          lineEl.classList.add('current');
+        }
+      });
+    }
+
+    function jumpToStep(targetStep) {
+      if (!currentWalkthrough) return;
+
+      // Reset editor and replay up to target step
+      const editorNode = document.getElementById('walkthrough-editor');
+      editorNode.className = 'wb no-select';
+      editorNode.innerHTML = `
+        <textarea class="wb-clipboard-bridge" aria-hidden="true"></textarea>
+        <div style="display: flex">
+          <div class="wb-gutter"></div>
+          <div class="wb-lines" style="flex: 1; overflow: hidden;"></div>
+        </div>
+        <div class="wb-status" style="display: flex; justify-content: space-between;">
+          <div class="wb-status-left" style="display: flex;">
+            <span class="wb-linecount"></span>
+          </div>
+          <div class="wb-status-right" style="display: flex;">
+            <span class="wb-coordinate"></span>
+            <span>|</span>
+            <span class="wb-indentation"></span>
+          </div>
+        </div>
+      `;
+
+      walkthroughEditor = new EditorFixture(editorNode);
+      walkthroughEditor.steps = currentWalkthrough.fixture.steps;
+      window.__walkthroughFixture = walkthroughEditor;
+
+      // Replay steps up to and including target
+      for (let i = 0; i <= targetStep; i++) {
+        walkthroughEditor.replayStep(i);
+      }
+
+      currentStep = targetStep + 1;
+      updateStepDisplay();
     }
 
     function escapeHtml(text) {

--- a/test/test.html
+++ b/test/test.html
@@ -379,7 +379,7 @@
         <strong id="walkthrough-test-name"></strong>
         <span style="margin-left: 12px; opacity: 0.7; font-size: 12px;" id="walkthrough-test-desc"></span>
       </div>
-      <button class="walkthrough-close" onclick="closeWalkthrough()">Close</button>
+      <button class="walkthrough-close" onclick="walkthrough.close()">Close</button>
     </div>
     <div class="walkthrough-body">
       <div class="walkthrough-left">
@@ -396,9 +396,9 @@
           <div class="wb" id="walkthrough-editor"></div>
         </div>
         <div class="step-controls-panel">
-          <button class="step-btn" id="step-prev" onclick="stepPrev()">← Previous</button>
+          <button class="step-btn" id="step-prev" onclick="walkthrough.stepPrev()">← Previous</button>
           <div class="step-info" id="step-info">Step 0 / 0</div>
-          <button class="step-btn" id="step-next" onclick="stepNext()">Next →</button>
+          <button class="step-btn" id="step-next" onclick="walkthrough.stepNext()">Next →</button>
         </div>
       </div>
     </div>
@@ -427,9 +427,14 @@
 
   <script src="../warrenbuf.js"></script>
   <script src="test-framework.js"></script>
+  <script src="walkthrough.js"></script>
   <script src="dsl.js"></script>
   <script src="expect.js"></script>
   <script src="test.spec.js"></script>
+  <script>
+    // Global walkthrough instance
+    const walkthrough = new Walkthrough();
+  </script>
   <script>
     // Render results
     function renderResults(results) {
@@ -463,8 +468,8 @@
           testDiv.className = `test-case ${test.status}`;
 
           const icon = test.status === 'pass' ? '✓' : test.status === 'fail' ? '✗' : '○';
-          const walkthroughBtn = test.fixture && test.fixture.steps && test.fixture.steps.length > 0
-            ? `<button class="walkthrough-btn" onclick="openWalkthrough('${suite.name}', ${testIndex})">Walkthrough</button>`
+          const walkthroughBtn = test.fixture && test.fixture.walkthrough && test.fixture.walkthrough.steps.length > 0
+            ? `<button class="walkthrough-btn" onclick="walkthrough.open('${suite.name}', ${testIndex})">Walkthrough</button>`
             : '';
 
           testDiv.innerHTML = `
@@ -513,348 +518,6 @@
     }
 
     window.addEventListener('DOMContentLoaded', runAllTests);
-
-    // Walkthrough state
-    let currentWalkthrough = null;
-    let currentStep = 0;
-    let walkthroughEditor = null;
-
-    function openWalkthrough(suiteName, testIndex) {
-      const suite = runner.suites.find(s => s.name === suiteName);
-      if (!suite) return;
-
-      const test = suite.results[testIndex];
-      if (!test || !test.fixture || !test.fixture.steps) return;
-
-      currentWalkthrough = test;
-      currentStep = 0;
-
-      // Update panel header
-      document.getElementById('walkthrough-test-name').textContent = test.name;
-      document.getElementById('walkthrough-test-desc').textContent = test.description || '';
-
-      // Display test code with inline step markers
-      const codeView = document.getElementById('walkthrough-code');
-      const sourceLines = test.fnSource.split('\n');
-
-      // Map steps to source code lines by matching step descriptions
-      const lineToStep = new Map();
-      let stepIndex = 0;
-
-      sourceLines.forEach((line, lineIndex) => {
-        if (stepIndex < test.fixture.steps.length) {
-          const step = test.fixture.steps[stepIndex];
-          // Check if this line contains the step action (type, press, etc.)
-          if (line.includes('.type(') || line.includes('.press(')) {
-            lineToStep.set(lineIndex, stepIndex);
-            stepIndex++;
-          }
-        }
-      });
-
-      // Find error line if test failed
-      let errorLineIndex = -1;
-      if (test.status === 'fail' && test.error) {
-        // Use the enhanced call stack we captured
-        const stackToUse = test.error.expectCallStack || test.error.stack;
-
-        if (stackToUse) {
-          // Parse stack to find the test function line
-          const stackLines = stackToUse.split('\n');
-
-          // Look for the line in the test function (usually has "at" and the function reference)
-          for (const stackLine of stackLines) {
-            // Match patterns like "eval:5:10" or "<anonymous>:5:10"
-            const match = stackLine.match(/<anonymous>:(\d+):(\d+)/);
-            if (match) {
-              const lineNum = parseInt(match[1]);
-              // Map to source line (accounting for function wrapper)
-              errorLineIndex = lineNum - 2; // Adjust for function declaration
-
-              if (errorLineIndex >= 0 && errorLineIndex < sourceLines.length) {
-                break;
-              }
-            }
-          }
-        }
-
-        // Better fallback: find the first expect() that matches the error message
-        if (errorLineIndex === -1 || errorLineIndex < 0 || errorLineIndex >= sourceLines.length) {
-          const errorMsg = test.error.message || '';
-          sourceLines.forEach((line, idx) => {
-            if (line.includes('expect(') && errorLineIndex === -1) {
-              errorLineIndex = idx;
-            }
-          });
-        }
-      }
-
-      // Find successful and failed expect lines using sequence numbers
-      const successLineIndices = new Set();
-      const failureLineIndices = new Set();
-
-      // Find all expect lines in the function source (in order)
-      const expectLines = [];
-      sourceLines.forEach((line, idx) => {
-        if (line.includes('expect(') && !line.trim().startsWith('//')) {
-          expectLines.push(idx);
-        }
-      });
-
-      // Map expect results to source lines by sequence number
-      // expectResults is sorted by execution order (sequence 0, 1, 2, ...)
-      const expectResults = test.expectResults || [];
-
-      expectResults.forEach((result, i) => {
-        if (i < expectLines.length) {
-          const lineIdx = expectLines[i];
-          if (result.success) {
-            successLineIndices.add(lineIdx);
-          } else {
-            failureLineIndices.add(lineIdx);
-          }
-        }
-      });
-
-      // Store expect data for progressive revealing
-      currentWalkthrough.expectData = {
-        successLineIndices,
-        failureLineIndices,
-        lineToStep
-      };
-
-      // Render source with step markers (expects hidden initially)
-      renderWalkthroughCode();
-
-      // Create editor instance
-      const editorNode = document.getElementById('walkthrough-editor');
-      editorNode.className = 'wb no-select';
-      editorNode.innerHTML = `
-        <textarea class="wb-clipboard-bridge" aria-hidden="true"></textarea>
-        <div style="display: flex">
-          <div class="wb-gutter"></div>
-          <div class="wb-lines" style="flex: 1; overflow: hidden;"></div>
-        </div>
-        <div class="wb-status" style="display: flex; justify-content: space-between;">
-          <div class="wb-status-left" style="display: flex;">
-            <span class="wb-linecount"></span>
-          </div>
-          <div class="wb-status-right" style="display: flex;">
-            <span class="wb-coordinate"></span>
-            <span>|</span>
-            <span class="wb-indentation"></span>
-          </div>
-        </div>
-      `;
-
-      walkthroughEditor = new EditorFixture(editorNode);
-
-      // Copy steps from test fixture to walkthrough fixture
-      walkthroughEditor.steps = test.fixture.steps;
-
-      // Expose to window for console debugging
-      window.__walkthroughFixture = walkthroughEditor;
-
-      // Show panel
-      document.getElementById('walkthrough-panel').classList.add('active');
-
-      // Update step display
-      updateStepDisplay();
-    }
-
-    function closeWalkthrough() {
-      document.getElementById('walkthrough-panel').classList.remove('active');
-      currentWalkthrough = null;
-      currentStep = 0;
-      walkthroughEditor = null;
-    }
-
-    function renderWalkthroughCode() {
-      if (!currentWalkthrough) return;
-
-      const test = currentWalkthrough;
-      const { successLineIndices, failureLineIndices, lineToStep } = test.expectData || {};
-      if (!lineToStep) return;
-
-      const codeView = document.getElementById('walkthrough-code');
-      const sourceLines = test.fnSource.split('\n');
-
-      // Determine which expects should be revealed based on current step
-      const totalSteps = currentWalkthrough.fixture.steps.length;
-      const isComplete = currentStep >= totalSteps;
-
-      // An expect is revealed if it comes before or at the current step position
-      // OR if we've completed all walkthrough steps (reveal all remaining expects)
-      let maxRevealedLine = -1;
-      if (currentStep > 0) {
-        // Find the line number of the last executed step
-        for (const [lineIdx, stepNum] of lineToStep.entries()) {
-          if (stepNum < currentStep) {
-            maxRevealedLine = Math.max(maxRevealedLine, lineIdx);
-          }
-        }
-      }
-
-      const codeHtml = sourceLines.map((line, lineIndex) => {
-        const stepNum = lineToStep.get(lineIndex);
-        const isStepLine = stepNum !== undefined;
-        const isFailureLine = failureLineIndices?.has(lineIndex);
-        const isSuccessLine = successLineIndices?.has(lineIndex);
-
-        // Show expect highlighting if we've passed this line OR completed all steps
-        const shouldRevealExpect = isComplete || lineIndex <= maxRevealedLine;
-
-        let classes = 'code-line';
-        if (isFailureLine && shouldRevealExpect) classes += ' error-line';
-        if (isSuccessLine && !isFailureLine && shouldRevealExpect) classes += ' success-line';
-        if (isStepLine) classes += ' step-line';
-
-        const onclick = isStepLine ? `onclick="jumpToStep(${stepNum})"` : '';
-
-        // Show markers
-        let marker = '';
-        if (isStepLine) {
-          marker += `<span class="step-marker">${stepNum + 1}</span>`;
-        }
-        if (isFailureLine && shouldRevealExpect) {
-          marker += `<span class="error-marker">✗</span>`;
-        } else if (isSuccessLine && shouldRevealExpect) {
-          marker += `<span class="success-marker">✓</span>`;
-        }
-
-        return `<div class="${classes}" data-step="${stepNum ?? ''}" ${onclick}>${marker}${escapeHtml(line)}</div>`;
-      }).join('');
-
-      codeView.innerHTML = codeHtml;
-    }
-
-    function stepNext() {
-      if (!currentWalkthrough || currentStep >= currentWalkthrough.fixture.steps.length) return;
-
-      // Replay the step on the walkthrough fixture
-      walkthroughEditor.replayStep(currentStep);
-
-      currentStep++;
-      updateStepDisplay();
-    }
-
-    function stepPrev() {
-      if (!currentWalkthrough || currentStep <= 0) return;
-
-      // Reset editor and replay up to previous step
-      const editorNode = document.getElementById('walkthrough-editor');
-      editorNode.className = 'wb no-select';
-      editorNode.innerHTML = `
-        <textarea class="wb-clipboard-bridge" aria-hidden="true"></textarea>
-        <div style="display: flex">
-          <div class="wb-gutter"></div>
-          <div class="wb-lines" style="flex: 1; overflow: hidden;"></div>
-        </div>
-        <div class="wb-status" style="display: flex; justify-content: space-between;">
-          <div class="wb-status-left" style="display: flex;">
-            <span class="wb-linecount"></span>
-          </div>
-          <div class="wb-status-right" style="display: flex;">
-            <span class="wb-coordinate"></span>
-            <span>|</span>
-            <span class="wb-indentation"></span>
-          </div>
-        </div>
-      `;
-
-      walkthroughEditor = new EditorFixture(editorNode);
-
-      // Copy steps from test fixture to walkthrough fixture
-      walkthroughEditor.steps = currentWalkthrough.fixture.steps;
-
-      // Expose to window for console debugging
-      window.__walkthroughFixture = walkthroughEditor;
-
-      currentStep--;
-
-      // Replay all steps up to current on the walkthrough fixture
-      for (let i = 0; i < currentStep; i++) {
-        walkthroughEditor.replayStep(i);
-      }
-
-      updateStepDisplay();
-    }
-
-    function updateStepDisplay() {
-      if (!currentWalkthrough) return;
-
-      const totalSteps = currentWalkthrough.fixture.steps.length;
-      const stepInfo = document.getElementById('step-info');
-
-      if (currentStep === 0) {
-        stepInfo.textContent = `Ready to start (${totalSteps} steps)`;
-      } else if (currentStep <= totalSteps) {
-        const step = currentWalkthrough.fixture.steps[currentStep - 1];
-        stepInfo.textContent = `Step ${currentStep}/${totalSteps}: ${step.description}`;
-      }
-
-      // Update button states
-      document.getElementById('step-prev').disabled = currentStep === 0;
-      document.getElementById('step-next').disabled = currentStep >= totalSteps;
-
-      // Re-render code view to update expect highlighting based on current step
-      renderWalkthroughCode();
-
-      // Update code line highlighting for steps (current/completed states)
-      const stepLines = document.querySelectorAll('.step-line');
-      stepLines.forEach((lineEl) => {
-        const stepNum = parseInt(lineEl.dataset.step);
-        lineEl.classList.remove('current', 'completed');
-        if (stepNum < currentStep - 1) {
-          lineEl.classList.add('completed');
-        } else if (stepNum === currentStep - 1) {
-          lineEl.classList.add('current');
-        }
-      });
-    }
-
-    function jumpToStep(targetStep) {
-      if (!currentWalkthrough) return;
-
-      // Reset editor and replay up to target step
-      const editorNode = document.getElementById('walkthrough-editor');
-      editorNode.className = 'wb no-select';
-      editorNode.innerHTML = `
-        <textarea class="wb-clipboard-bridge" aria-hidden="true"></textarea>
-        <div style="display: flex">
-          <div class="wb-gutter"></div>
-          <div class="wb-lines" style="flex: 1; overflow: hidden;"></div>
-        </div>
-        <div class="wb-status" style="display: flex; justify-content: space-between;">
-          <div class="wb-status-left" style="display: flex;">
-            <span class="wb-linecount"></span>
-          </div>
-          <div class="wb-status-right" style="display: flex;">
-            <span class="wb-coordinate"></span>
-            <span>|</span>
-            <span class="wb-indentation"></span>
-          </div>
-        </div>
-      `;
-
-      walkthroughEditor = new EditorFixture(editorNode);
-      walkthroughEditor.steps = currentWalkthrough.fixture.steps;
-      window.__walkthroughFixture = walkthroughEditor;
-
-      // Replay steps up to and including target
-      for (let i = 0; i <= targetStep; i++) {
-        walkthroughEditor.replayStep(i);
-      }
-
-      currentStep = targetStep + 1;
-      updateStepDisplay();
-    }
-
-    function escapeHtml(text) {
-      const div = document.createElement('div');
-      div.textContent = text;
-      return div.innerHTML;
-    }
   </script>
 </body>
 </html>

--- a/test/test.html
+++ b/test/test.html
@@ -616,11 +616,6 @@
         }
       });
 
-      console.log('Expect lines in source:', expectLines);
-      console.log('Expect results:', expectResults);
-      console.log('Success lines:', Array.from(successLineIndices));
-      console.log('Failure lines:', Array.from(failureLineIndices));
-
       // Store expect data for progressive revealing
       currentWalkthrough.expectData = {
         successLineIndices,
@@ -630,25 +625,6 @@
 
       // Render source with step markers (expects hidden initially)
       renderWalkthroughCode();
-
-      // Debug: log expect detection
-      console.log('Test:', test.name, 'Status:', test.status);
-      console.log('test.successfulExpects:', test.successfulExpects);
-      console.log('Successful expect lines:', Array.from(successLineIndices));
-      if (test.status === 'fail') {
-        console.log('Error line index:', errorLineIndex);
-        console.log('Error:', test.error);
-        if (errorLineIndex >= 0 && errorLineIndex < sourceLines.length) {
-          console.log('Error line content:', sourceLines[errorLineIndex]);
-        }
-      }
-
-      // Debug: show all expect lines
-      sourceLines.forEach((line, idx) => {
-        if (line.includes('expect(')) {
-          console.log(`Line ${idx}: ${line.trim()} - Success: ${successLineIndices.has(idx)}, Error: ${idx === errorLineIndex}`);
-        }
-      });
 
       // Create editor instance
       const editorNode = document.getElementById('walkthrough-editor');

--- a/test/test.html
+++ b/test/test.html
@@ -172,10 +172,6 @@
     .wb .wb-status span {
       padding-right: 4px;
     }
-    #walkthrough-editor .wb {
-      width: 100%;
-      height: 100%;
-    }
     @keyframes shake {
       0%, 100% { transform: translateX(0); }
       10%, 30%, 50%, 70%, 90% { transform: translateX(-4px); }
@@ -292,7 +288,7 @@
       font-size: 13px;
       color: #d4d4d4;
     }
-    .editor-view {
+    .editor-view-container {
       flex: 1;
       padding: 16px;
       overflow: auto;
@@ -343,7 +339,9 @@
         <div style="padding: 12px 16px; background: #2d2d30; border-bottom: 1px solid #3e3e3e;">
           <strong>Editor</strong>
         </div>
-        <div class="editor-view" id="walkthrough-editor"></div>
+        <div class="editor-view-container">
+          <div class="wb" id="walkthrough-editor"></div>
+        </div>
         <div class="step-controls-panel">
           <button class="step-btn" id="step-prev" onclick="stepPrev()">← Previous</button>
           <div class="step-info" id="step-info">Step 0 / 0</div>
@@ -487,28 +485,26 @@
       codeView.innerHTML = `<pre>${escapeHtml(test.fnSource)}</pre>`;
 
       // Create editor instance
-      const editorContainer = document.getElementById('walkthrough-editor');
-      editorContainer.innerHTML = `
-        <div class="wb no-select" style="width: 100%; height: 100%;">
-          <textarea class="wb-clipboard-bridge" aria-hidden="true"></textarea>
-          <div style="display: flex">
-            <div class="wb-gutter"></div>
-            <div class="wb-lines" style="flex: 1; overflow: hidden;"></div>
+      const editorNode = document.getElementById('walkthrough-editor');
+      editorNode.className = 'wb no-select';
+      editorNode.innerHTML = `
+        <textarea class="wb-clipboard-bridge" aria-hidden="true"></textarea>
+        <div style="display: flex">
+          <div class="wb-gutter"></div>
+          <div class="wb-lines" style="flex: 1; overflow: hidden;"></div>
+        </div>
+        <div class="wb-status" style="display: flex; justify-content: space-between;">
+          <div class="wb-status-left" style="display: flex;">
+            <span class="wb-linecount"></span>
           </div>
-          <div class="wb-status" style="display: flex; justify-content: space-between;">
-            <div class="wb-status-left" style="display: flex;">
-              <span class="wb-linecount"></span>
-            </div>
-            <div class="wb-status-right" style="display: flex;">
-              <span class="wb-coordinate"></span>
-              <span>|</span>
-              <span class="wb-indentation"></span>
-            </div>
+          <div class="wb-status-right" style="display: flex;">
+            <span class="wb-coordinate"></span>
+            <span>|</span>
+            <span class="wb-indentation"></span>
           </div>
         </div>
       `;
 
-      const editorNode = editorContainer.querySelector('.wb');
       walkthroughEditor = new EditorFixture(editorNode);
 
       // Copy steps from test fixture to walkthrough fixture
@@ -545,8 +541,26 @@
       if (!currentWalkthrough || currentStep <= 0) return;
 
       // Reset editor and replay up to previous step
-      const editorContainer = document.getElementById('walkthrough-editor');
-      const editorNode = editorContainer.querySelector('.wb');
+      const editorNode = document.getElementById('walkthrough-editor');
+      editorNode.className = 'wb no-select';
+      editorNode.innerHTML = `
+        <textarea class="wb-clipboard-bridge" aria-hidden="true"></textarea>
+        <div style="display: flex">
+          <div class="wb-gutter"></div>
+          <div class="wb-lines" style="flex: 1; overflow: hidden;"></div>
+        </div>
+        <div class="wb-status" style="display: flex; justify-content: space-between;">
+          <div class="wb-status-left" style="display: flex;">
+            <span class="wb-linecount"></span>
+          </div>
+          <div class="wb-status-right" style="display: flex;">
+            <span class="wb-coordinate"></span>
+            <span>|</span>
+            <span class="wb-indentation"></span>
+          </div>
+        </div>
+      `;
+
       walkthroughEditor = new EditorFixture(editorNode);
 
       // Copy steps from test fixture to walkthrough fixture

--- a/test/test.html
+++ b/test/test.html
@@ -291,6 +291,17 @@
       color: #f44336;
       font-weight: bold;
     }
+    .code-line.success-line {
+      background: #1e3a1e;
+      border-left: 3px solid #4CAF50;
+      padding-left: 5px;
+    }
+    .success-marker {
+      display: inline-block;
+      margin-right: 8px;
+      color: #4CAF50;
+      font-weight: bold;
+    }
     .step-marker {
       display: inline-block;
       width: 25px;
@@ -543,24 +554,33 @@
 
       // Find error line if test failed
       let errorLineIndex = -1;
-      if (test.status === 'fail' && test.error && test.error.stack) {
-        // Try to extract line number from error stack
-        // Look for patterns like "at <anonymous>:5:10" or similar
-        const stackLines = test.error.stack.split('\n');
-        for (const stackLine of stackLines) {
-          // Match patterns like ":lineNum:" in the stack trace
-          const match = stackLine.match(/:(\d+):/);
-          if (match) {
-            const absoluteLine = parseInt(match[1]);
-            // The line numbers in stack traces are 1-based and refer to the function body
-            // We need to map this to our source line index
-            errorLineIndex = absoluteLine - 2; // Adjust for function wrapper
-            break;
+      if (test.status === 'fail' && test.error) {
+        // Use the enhanced call stack we captured
+        const stackToUse = test.error.expectCallStack || test.error.stack;
+
+        if (stackToUse) {
+          // Parse stack to find the test function line
+          const stackLines = stackToUse.split('\n');
+
+          // Look for the line in the test function (usually has "at" and the function reference)
+          for (const stackLine of stackLines) {
+            // Match patterns like "eval:5:10" or "<anonymous>:5:10"
+            const match = stackLine.match(/<anonymous>:(\d+):(\d+)/);
+            if (match) {
+              const lineNum = parseInt(match[1]);
+              // Map to source line (accounting for function wrapper)
+              errorLineIndex = lineNum - 2; // Adjust for function declaration
+
+              if (errorLineIndex >= 0 && errorLineIndex < sourceLines.length) {
+                break;
+              }
+            }
           }
         }
 
-        // Fallback: look for expect() calls that might have failed
+        // Better fallback: find the first expect() that matches the error message
         if (errorLineIndex === -1 || errorLineIndex < 0 || errorLineIndex >= sourceLines.length) {
+          const errorMsg = test.error.message || '';
           sourceLines.forEach((line, idx) => {
             if (line.includes('expect(') && errorLineIndex === -1) {
               errorLineIndex = idx;
@@ -569,24 +589,86 @@
         }
       }
 
+      // Find successful and failed expect lines using sequence numbers
+      const successLineIndices = new Set();
+      const failureLineIndices = new Set();
+
+      // Find all expect lines in the function source (in order)
+      const expectLines = [];
+      sourceLines.forEach((line, idx) => {
+        if (line.includes('expect(') && !line.trim().startsWith('//')) {
+          expectLines.push(idx);
+        }
+      });
+
+      // Map expect results to source lines by sequence number
+      // expectResults is sorted by execution order (sequence 0, 1, 2, ...)
+      const expectResults = test.expectResults || [];
+
+      expectResults.forEach((result, i) => {
+        if (i < expectLines.length) {
+          const lineIdx = expectLines[i];
+          if (result.success) {
+            successLineIndices.add(lineIdx);
+          } else {
+            failureLineIndices.add(lineIdx);
+          }
+        }
+      });
+
+      console.log('Expect lines in source:', expectLines);
+      console.log('Expect results:', expectResults);
+      console.log('Success lines:', Array.from(successLineIndices));
+      console.log('Failure lines:', Array.from(failureLineIndices));
+
       // Render source with step markers and error highlighting
       const codeHtml = sourceLines.map((line, lineIndex) => {
         const stepNum = lineToStep.get(lineIndex);
         const isStepLine = stepNum !== undefined;
-        const isErrorLine = lineIndex === errorLineIndex;
+        const isFailureLine = failureLineIndices.has(lineIndex);
+        const isSuccessLine = successLineIndices.has(lineIndex);
 
         let classes = 'code-line';
-        if (isErrorLine) classes += ' error-line';
+        if (isFailureLine) classes += ' error-line';
+        if (isSuccessLine && !isFailureLine) classes += ' success-line';
         if (isStepLine) classes += ' step-line';
 
         const onclick = isStepLine ? `onclick="jumpToStep(${stepNum})"` : '';
-        const marker = isStepLine ? `<span class="step-marker">${stepNum + 1}</span>` :
-                       isErrorLine ? `<span class="error-marker">✗</span>` : '';
+
+        // Show markers
+        let marker = '';
+        if (isStepLine) {
+          marker += `<span class="step-marker">${stepNum + 1}</span>`;
+        }
+        if (isFailureLine) {
+          marker += `<span class="error-marker">✗</span>`;
+        } else if (isSuccessLine) {
+          marker += `<span class="success-marker">✓</span>`;
+        }
 
         return `<div class="${classes}" data-step="${stepNum ?? ''}" ${onclick}>${marker}${escapeHtml(line)}</div>`;
       }).join('');
 
       codeView.innerHTML = codeHtml;
+
+      // Debug: log expect detection
+      console.log('Test:', test.name, 'Status:', test.status);
+      console.log('test.successfulExpects:', test.successfulExpects);
+      console.log('Successful expect lines:', Array.from(successLineIndices));
+      if (test.status === 'fail') {
+        console.log('Error line index:', errorLineIndex);
+        console.log('Error:', test.error);
+        if (errorLineIndex >= 0 && errorLineIndex < sourceLines.length) {
+          console.log('Error line content:', sourceLines[errorLineIndex]);
+        }
+      }
+
+      // Debug: show all expect lines
+      sourceLines.forEach((line, idx) => {
+        if (line.includes('expect(')) {
+          console.log(`Line ${idx}: ${line.trim()} - Success: ${successLineIndices.has(idx)}, Error: ${idx === errorLineIndex}`);
+        }
+      });
 
       // Create editor instance
       const editorNode = document.getElementById('walkthrough-editor');

--- a/test/test.html
+++ b/test/test.html
@@ -509,7 +509,13 @@
       `;
 
       const editorNode = editorContainer.querySelector('.wb');
-      walkthroughEditor = new WarrenBuf(editorNode);
+      walkthroughEditor = new EditorFixture(editorNode);
+
+      // Copy steps from test fixture to walkthrough fixture
+      walkthroughEditor.steps = test.fixture.steps;
+
+      // Expose to window for console debugging
+      window.__walkthroughFixture = walkthroughEditor;
 
       // Show panel
       document.getElementById('walkthrough-panel').classList.add('active');
@@ -528,8 +534,8 @@
     function stepNext() {
       if (!currentWalkthrough || currentStep >= currentWalkthrough.fixture.steps.length) return;
 
-      const step = currentWalkthrough.fixture.steps[currentStep];
-      step.action();
+      // Replay the step on the walkthrough fixture
+      walkthroughEditor.replayStep(currentStep);
 
       currentStep++;
       updateStepDisplay();
@@ -541,13 +547,19 @@
       // Reset editor and replay up to previous step
       const editorContainer = document.getElementById('walkthrough-editor');
       const editorNode = editorContainer.querySelector('.wb');
-      walkthroughEditor = new WarrenBuf(editorNode);
+      walkthroughEditor = new EditorFixture(editorNode);
+
+      // Copy steps from test fixture to walkthrough fixture
+      walkthroughEditor.steps = currentWalkthrough.fixture.steps;
+
+      // Expose to window for console debugging
+      window.__walkthroughFixture = walkthroughEditor;
 
       currentStep--;
 
-      // Replay all steps up to current
+      // Replay all steps up to current on the walkthrough fixture
       for (let i = 0; i < currentStep; i++) {
-        currentWalkthrough.fixture.steps[i].action();
+        walkthroughEditor.replayStep(i);
       }
 
       updateStepDisplay();

--- a/test/test.html
+++ b/test/test.html
@@ -140,6 +140,42 @@
       font-family: monospace;
       border: 1px solid black;
     }
+    .no-select {
+      user-select: none;       /* Standard */
+      -webkit-user-select: none; /* Safari */
+      -moz-user-select: none;    /* Firefox */
+      -ms-user-select: none;     /* IE/Edge (old) */
+    }
+    .wb-clipboard-bridge {
+      position: fixed;      /* out of normal flow so it won't jump layout */
+      left: 0;
+      top: 1px;
+      width: 0;
+      height: 1px;
+      opacity: 0;
+      pointer-events: none; /* avoid clicks */
+    }
+    .wb .wb-lines>pre::before {
+      content: "\200B";
+    }
+    .wb .wb-lines pre {
+      margin: 0;
+      overflow: hidden;
+    }
+    .wb .wb-selection {
+      left: 0ch;
+      top: 0ch;
+      background-color: #EDAD10;
+      position: absolute;
+      mix-blend-mode: difference;        /* inverts underlying pixels */
+    }
+    .wb .wb-status span {
+      padding-right: 4px;
+    }
+    #walkthrough-editor .wb {
+      width: 100%;
+      height: 100%;
+    }
     @keyframes shake {
       0%, 100% { transform: translateX(0); }
       10%, 30%, 50%, 70%, 90% { transform: translateX(-4px); }

--- a/test/test.html
+++ b/test/test.html
@@ -148,6 +148,119 @@
     .shake {
       animation: shake 0.5s;
     }
+    .walkthrough-btn {
+      background: #9c640e;
+      color: white;
+      border: none;
+      padding: 4px 12px;
+      border-radius: 3px;
+      cursor: pointer;
+      font-size: 12px;
+      margin-left: 8px;
+    }
+    .walkthrough-btn:hover {
+      background: #bb7711;
+    }
+    .walkthrough-panel {
+      position: fixed;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      height: 0;
+      background: #1e1e1e;
+      border-top: 2px solid #4EC9B0;
+      z-index: 1000;
+      overflow: hidden;
+      transition: height 0.3s ease;
+      display: flex;
+      flex-direction: column;
+    }
+    .walkthrough-panel.active {
+      height: 70vh;
+    }
+    .walkthrough-header {
+      background: #2d2d30;
+      padding: 12px 16px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      border-bottom: 1px solid #3e3e3e;
+    }
+    .walkthrough-close {
+      background: #f44336;
+      color: white;
+      border: none;
+      padding: 6px 12px;
+      border-radius: 3px;
+      cursor: pointer;
+      font-size: 12px;
+    }
+    .walkthrough-body {
+      display: flex;
+      flex: 1;
+      min-height: 0;
+    }
+    .walkthrough-left {
+      flex: 1;
+      background: #252526;
+      border-right: 1px solid #3e3e3e;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+    .walkthrough-right {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+    .code-view {
+      flex: 1;
+      overflow: auto;
+      padding: 16px;
+      font-family: 'Courier New', monospace;
+      font-size: 13px;
+      line-height: 1.5;
+    }
+    .code-view pre {
+      margin: 0;
+      color: #d4d4d4;
+    }
+    .step-controls-panel {
+      background: #2d2d30;
+      padding: 12px 16px;
+      border-top: 1px solid #3e3e3e;
+      display: flex;
+      gap: 8px;
+      align-items: center;
+    }
+    .step-btn {
+      background: #0e639c;
+      color: white;
+      border: none;
+      padding: 8px 16px;
+      border-radius: 3px;
+      cursor: pointer;
+      font-size: 13px;
+    }
+    .step-btn:hover {
+      background: #1177bb;
+    }
+    .step-btn:disabled {
+      background: #555;
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
+    .step-info {
+      flex: 1;
+      font-size: 13px;
+      color: #d4d4d4;
+    }
+    .editor-view {
+      flex: 1;
+      padding: 16px;
+      overflow: auto;
+    }
   </style>
 </head>
 <body>
@@ -173,6 +286,36 @@
   </div>
 
   <div id="test-results"></div>
+
+  <!-- Walkthrough panel -->
+  <div id="walkthrough-panel" class="walkthrough-panel">
+    <div class="walkthrough-header">
+      <div>
+        <strong id="walkthrough-test-name"></strong>
+        <span style="margin-left: 12px; opacity: 0.7; font-size: 12px;" id="walkthrough-test-desc"></span>
+      </div>
+      <button class="walkthrough-close" onclick="closeWalkthrough()">Close</button>
+    </div>
+    <div class="walkthrough-body">
+      <div class="walkthrough-left">
+        <div style="padding: 12px 16px; background: #2d2d30; border-bottom: 1px solid #3e3e3e;">
+          <strong>Test Code</strong>
+        </div>
+        <div class="code-view" id="walkthrough-code"></div>
+      </div>
+      <div class="walkthrough-right">
+        <div style="padding: 12px 16px; background: #2d2d30; border-bottom: 1px solid #3e3e3e;">
+          <strong>Editor</strong>
+        </div>
+        <div class="editor-view" id="walkthrough-editor"></div>
+        <div class="step-controls-panel">
+          <button class="step-btn" id="step-prev" onclick="stepPrev()">← Previous</button>
+          <div class="step-info" id="step-info">Step 0 / 0</div>
+          <button class="step-btn" id="step-next" onclick="stepNext()">Next →</button>
+        </div>
+      </div>
+    </div>
+  </div>
 
   <!-- Hidden editor container for tests -->
   <div class="editor-container">
@@ -228,11 +371,15 @@
         const suiteBody = document.createElement('div');
         suiteBody.className = 'test-suite-body';
 
-        suite.results.forEach(test => {
+        suite.results.forEach((test, testIndex) => {
           const testDiv = document.createElement('div');
           testDiv.className = `test-case ${test.status}`;
 
           const icon = test.status === 'pass' ? '✓' : test.status === 'fail' ? '✗' : '○';
+          const walkthroughBtn = test.fixture && test.fixture.steps && test.fixture.steps.length > 0
+            ? `<button class="walkthrough-btn" onclick="openWalkthrough('${suite.name}', ${testIndex})">Walkthrough</button>`
+            : '';
+
           testDiv.innerHTML = `
             <span class="test-icon ${test.status}">${icon}</span>
             <div class="test-message">
@@ -240,6 +387,7 @@
               ${test.description ? `<div class="test-description">${test.description}</div>` : ''}
               ${test.error ? `<div class="test-error">${test.error.message}</div>` : ''}
             </div>
+            ${walkthroughBtn}
           `;
 
           suiteBody.appendChild(testDiv);
@@ -278,6 +426,122 @@
     }
 
     window.addEventListener('DOMContentLoaded', runAllTests);
+
+    // Walkthrough state
+    let currentWalkthrough = null;
+    let currentStep = 0;
+    let walkthroughEditor = null;
+
+    function openWalkthrough(suiteName, testIndex) {
+      const suite = runner.suites.find(s => s.name === suiteName);
+      if (!suite) return;
+
+      const test = suite.results[testIndex];
+      if (!test || !test.fixture || !test.fixture.steps) return;
+
+      currentWalkthrough = test;
+      currentStep = 0;
+
+      // Update panel header
+      document.getElementById('walkthrough-test-name').textContent = test.name;
+      document.getElementById('walkthrough-test-desc').textContent = test.description || '';
+
+      // Display test code
+      const codeView = document.getElementById('walkthrough-code');
+      codeView.innerHTML = `<pre>${escapeHtml(test.fnSource)}</pre>`;
+
+      // Create editor instance
+      const editorContainer = document.getElementById('walkthrough-editor');
+      editorContainer.innerHTML = `
+        <div class="wb no-select" style="width: 100%; height: 100%;">
+          <textarea class="wb-clipboard-bridge" aria-hidden="true"></textarea>
+          <div style="display: flex">
+            <div class="wb-gutter"></div>
+            <div class="wb-lines" style="flex: 1; overflow: hidden;"></div>
+          </div>
+          <div class="wb-status" style="display: flex; justify-content: space-between;">
+            <div class="wb-status-left" style="display: flex;">
+              <span class="wb-linecount"></span>
+            </div>
+            <div class="wb-status-right" style="display: flex;">
+              <span class="wb-coordinate"></span>
+              <span>|</span>
+              <span class="wb-indentation"></span>
+            </div>
+          </div>
+        </div>
+      `;
+
+      const editorNode = editorContainer.querySelector('.wb');
+      walkthroughEditor = new WarrenBuf(editorNode);
+
+      // Show panel
+      document.getElementById('walkthrough-panel').classList.add('active');
+
+      // Update step display
+      updateStepDisplay();
+    }
+
+    function closeWalkthrough() {
+      document.getElementById('walkthrough-panel').classList.remove('active');
+      currentWalkthrough = null;
+      currentStep = 0;
+      walkthroughEditor = null;
+    }
+
+    function stepNext() {
+      if (!currentWalkthrough || currentStep >= currentWalkthrough.fixture.steps.length) return;
+
+      const step = currentWalkthrough.fixture.steps[currentStep];
+      step.action();
+
+      currentStep++;
+      updateStepDisplay();
+    }
+
+    function stepPrev() {
+      if (!currentWalkthrough || currentStep <= 0) return;
+
+      // Reset editor and replay up to previous step
+      const editorContainer = document.getElementById('walkthrough-editor');
+      const editorNode = editorContainer.querySelector('.wb');
+      walkthroughEditor = new WarrenBuf(editorNode);
+
+      currentStep--;
+
+      // Replay all steps up to current
+      for (let i = 0; i < currentStep; i++) {
+        currentWalkthrough.fixture.steps[i].action();
+      }
+
+      updateStepDisplay();
+    }
+
+    function updateStepDisplay() {
+      if (!currentWalkthrough) return;
+
+      const totalSteps = currentWalkthrough.fixture.steps.length;
+      const stepInfo = document.getElementById('step-info');
+
+      if (currentStep === 0) {
+        stepInfo.textContent = `Ready to start (${totalSteps} steps)`;
+      } else if (currentStep < totalSteps) {
+        const step = currentWalkthrough.fixture.steps[currentStep - 1];
+        stepInfo.textContent = `Step ${currentStep}/${totalSteps}: ${step.description}`;
+      } else {
+        stepInfo.textContent = `Complete (${totalSteps}/${totalSteps})`;
+      }
+
+      // Update button states
+      document.getElementById('step-prev').disabled = currentStep === 0;
+      document.getElementById('step-next').disabled = currentStep >= totalSteps;
+    }
+
+    function escapeHtml(text) {
+      const div = document.createElement('div');
+      div.textContent = text;
+      return div.innerHTML;
+    }
   </script>
 </body>
 </html>

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -327,14 +327,18 @@ runner.describe('Cursor movement - varying line lengths', () => {
     fixture.type('Much longer line');
     // Assert cursor position after typing
     let [firstEdge, SecondEdge] = fixture.wb.Selection.ordered;
-    expect(firstEdge).toEqual(null); // TEMPORARY: Intentionally failing to test walkthrough behavior
-    expect(SecondEdge).toEqual({ row: 1, col: 16 });
+    // expect(firstEdge).toEqual(null); // TEMPORARY: Intentionally failing to test walkthrough behavior
+    // expect(SecondEdge).toEqual({ row: 1, col: 16 });
+    expect(1).toEqual(null); // TEMPORARY: fail
+    expect(1).toBe(1); // TEMPORARY: succeed
 
     fixture.press(Key.ArrowUp).once();  // Move to "Short", col clamped to 5
     fixture.press(Key.ArrowDown).once(); // Move back to "Much longer line"
     [firstEdge, SecondEdge] = fixture.wb.Selection.ordered;
-    expect(firstEdge).toEqual({ row: 1, col: 16 }); // Should restore to col 16
-    expect(SecondEdge).toEqual({ row: 1, col: 16 });
+    // expect(firstEdge).toEqual({ row: 1, col: 16 }); // Should restore to col 16
+    // expect(SecondEdge).toEqual({ row: 1, col: 16 });
+    expect(1).toBe(3); // TEMPORARY: fail
+    expect(5).toBe(5); // TEMPORARY: succeed
   }, "Should restore original column when moving back");
 
   runner.it('should clamp column to line end on shorter line', () => {

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -1,38 +1,10 @@
 // Test definitions
 const runner = new TestRunner();
 
-// Helper to create a new DOM node for EditorFixture
-function createEditorNode() {
-  const container = document.querySelector('.editor-container');
-  const node = document.createElement('div');
-  node.className = 'wb no-select';
-  node.innerHTML = `
-    <textarea class="wb-clipboard-bridge" aria-hidden="true"></textarea>
-    <div style="display: flex">
-      <div class="wb-gutter"></div>
-      <div class="wb-lines" style="flex: 1; overflow: hidden;"></div>
-    </div>
-    <div class="wb-status" style="display: flex; justify-content: space-between;">
-      <div class="wb-status-left" style="display: flex;">
-        <span class="wb-linecount"></span>
-      </div>
-      <div class="wb-status-right" style="display: flex;">
-        <span class="wb-coordinate"></span>
-        <span>|</span>
-        <span class="wb-indentation"></span>
-      </div>
-    </div>
-  `;
-
-  container.innerHTML = '';
-  container.appendChild(node);
-  return node;
-}
-
 // Basic Typing Tests
 runner.describe('Basic Typing', () => {
   let fixture;
-  runner.beforeEach(() => fixture = new EditorFixture(createEditorNode()));
+  runner.beforeEach(() => fixture = FixtureFactory.forTest());
 
   runner.it('should insert single character', () => {
     fixture.press('a').once();
@@ -66,7 +38,7 @@ runner.describe('Backspace', () => {
   let fixture;
 
   runner.beforeEach(() => {
-    fixture = new EditorFixture(createEditorNode());
+    fixture = FixtureFactory.forTest();
   });
 
   runner.it('should delete single character', () => {
@@ -122,7 +94,7 @@ runner.describe('Enter Key', () => {
   let fixture;
 
   runner.beforeEach(() => {
-    fixture = new EditorFixture(createEditorNode());
+    fixture = FixtureFactory.forTest();
   });
 
   runner.it('should create new line', () => {
@@ -173,7 +145,7 @@ runner.describe('Complex Sequences', () => {
   let fixture;
 
   runner.beforeEach(() => {
-    fixture = new EditorFixture(createEditorNode());
+    fixture = FixtureFactory.forTest();
   });
 
   runner.it('should type, delete, and retype', () => {
@@ -243,7 +215,7 @@ runner.describe('Selection', () => {
   let fixture;
 
   runner.beforeEach(() => {
-    fixture = new EditorFixture(createEditorNode());
+    fixture = FixtureFactory.forTest();
   });
 
   runner.it('should create selection with Shift+ArrowRight', () => {
@@ -336,7 +308,7 @@ runner.describe('Cursor movement - varying line lengths', () => {
   let fixture;
 
   runner.beforeEach(() => {
-    fixture = new EditorFixture(createEditorNode());
+    fixture = FixtureFactory.forTest();
   });
 
   runner.it('should preserve column when moving from long to short line', () => {
@@ -456,7 +428,7 @@ runner.describe('Meta+Arrow navigation', () => {
   let fixture;
 
   runner.beforeEach(() => {
-    fixture = new EditorFixture(createEditorNode());
+    fixture = FixtureFactory.forTest();
   });
 
   runner.it('should move to end of line with Meta+Right', () => {
@@ -522,7 +494,7 @@ runner.describe('Shift+Meta+Arrow selection', () => {
   let fixture;
 
   runner.beforeEach(() => {
-    fixture = new EditorFixture(createEditorNode());
+    fixture = FixtureFactory.forTest();
   });
 
   runner.it('should select to end of line with Shift+Meta+Right', () => {
@@ -592,7 +564,7 @@ runner.describe('Multi-line selections', () => {
   let fixture;
 
   runner.beforeEach(() => {
-    fixture = new EditorFixture(createEditorNode());
+    fixture = FixtureFactory.forTest();
   });
 
   runner.it('should select 3 rows with start in middle, end in middle', () => {
@@ -807,7 +779,7 @@ runner.describe('Deleting selections', () => {
   let fixture;
 
   runner.beforeEach(() => {
-    fixture = new EditorFixture(createEditorNode());
+    fixture = FixtureFactory.forTest();
   });
 
   runner.it('should delete single line selection with Backspace', () => {
@@ -921,7 +893,7 @@ runner.describe('Replacing selections', () => {
   let fixture;
 
   runner.beforeEach(() => {
-    fixture = new EditorFixture(createEditorNode());
+    fixture = FixtureFactory.forTest();
   });
 
   runner.it('should replace single line selection with typed character', () => {
@@ -1046,7 +1018,7 @@ runner.describe('Regression: Selection.ordered and isForwardSelection', () => {
   let fixture;
 
   runner.beforeEach(() => {
-    fixture = new EditorFixture(createEditorNode());
+    fixture = FixtureFactory.forTest();
   });
 
   runner.it('should correctly identify forward selection when tail < head', () => {
@@ -1117,7 +1089,7 @@ runner.describe('Walkthrough feature - regression tests', () => {
   let fixture;
 
   runner.beforeEach(() => {
-    fixture = new EditorFixture(createEditorNode());
+    fixture = FixtureFactory.forTest();
   });
 
   runner.it('should demonstrate interleaved success and failure expects', () => {

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -327,18 +327,14 @@ runner.describe('Cursor movement - varying line lengths', () => {
     fixture.type('Much longer line');
     // Assert cursor position after typing
     let [firstEdge, SecondEdge] = fixture.wb.Selection.ordered;
-    // expect(firstEdge).toEqual(null); // TEMPORARY: Intentionally failing to test walkthrough behavior
-    // expect(SecondEdge).toEqual({ row: 1, col: 16 });
-    expect(1).toEqual(null); // TEMPORARY: fail
-    expect(1).toBe(1); // TEMPORARY: succeed
+    expect(firstEdge).toEqual({ row: 1, col: 16 }); // One past last char
+    expect(SecondEdge).toEqual({ row: 1, col: 16 });
 
     fixture.press(Key.ArrowUp).once();  // Move to "Short", col clamped to 5
     fixture.press(Key.ArrowDown).once(); // Move back to "Much longer line"
     [firstEdge, SecondEdge] = fixture.wb.Selection.ordered;
-    // expect(firstEdge).toEqual({ row: 1, col: 16 }); // Should restore to col 16
-    // expect(SecondEdge).toEqual({ row: 1, col: 16 });
-    expect(1).toBe(3); // TEMPORARY: fail
-    expect(5).toBe(5); // TEMPORARY: succeed
+    expect(firstEdge).toEqual({ row: 1, col: 16 }); // Should restore to col 16
+    expect(SecondEdge).toEqual({ row: 1, col: 16 });
   }, "Should restore original column when moving back");
 
   runner.it('should clamp column to line end on shorter line', () => {
@@ -1085,4 +1081,28 @@ runner.describe('Regression: Selection.ordered and isForwardSelection', () => {
     expect(start).toEqual({ row: 0, col: 0 });
     expect(end).toEqual({row: 2, col: 0});
   }, "Clamps using head.row when head moves to shorter line");
+});
+
+// Walkthrough feature tests
+// These tests specifically validate the walkthrough UI with known pass/fail expects
+runner.describe('Walkthrough feature - regression tests', () => {
+  let fixture;
+
+  runner.beforeEach(() => {
+    fixture = new EditorFixture();
+  });
+
+  runner.it('should demonstrate interleaved success and failure expects', () => {
+    fixture.type('First line');
+    expect(1).toEqual(null); // Intentional fail for walkthrough demo
+
+    fixture.press(Key.Enter).once();
+    expect(1).toBe(1); // Intentional success for walkthrough demo
+
+    fixture.type('Second line');
+    expect(1).toBe(3); // Intentional fail for walkthrough demo
+
+    fixture.press(Key.ArrowLeft).withMetaKey().once();
+    expect(5).toBe(5); // Intentional success for walkthrough demo
+  }, "Interleaved success/fail expects for walkthrough testing");
 });

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -327,7 +327,7 @@ runner.describe('Cursor movement - varying line lengths', () => {
     fixture.type('Much longer line');
     // Assert cursor position after typing
     let [firstEdge, SecondEdge] = fixture.wb.Selection.ordered;
-    expect(firstEdge).toEqual({ row: 1, col: 16 }); // One past last char
+    expect(firstEdge).toEqual(null); // TEMPORARY: Intentionally failing to test walkthrough behavior
     expect(SecondEdge).toEqual({ row: 1, col: 16 });
 
     fixture.press(Key.ArrowUp).once();  // Move to "Short", col clamped to 5

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -1,10 +1,38 @@
 // Test definitions
 const runner = new TestRunner();
 
+// Helper to create a new DOM node for EditorFixture
+function createEditorNode() {
+  const container = document.querySelector('.editor-container');
+  const node = document.createElement('div');
+  node.className = 'wb no-select';
+  node.innerHTML = `
+    <textarea class="wb-clipboard-bridge" aria-hidden="true"></textarea>
+    <div style="display: flex">
+      <div class="wb-gutter"></div>
+      <div class="wb-lines" style="flex: 1; overflow: hidden;"></div>
+    </div>
+    <div class="wb-status" style="display: flex; justify-content: space-between;">
+      <div class="wb-status-left" style="display: flex;">
+        <span class="wb-linecount"></span>
+      </div>
+      <div class="wb-status-right" style="display: flex;">
+        <span class="wb-coordinate"></span>
+        <span>|</span>
+        <span class="wb-indentation"></span>
+      </div>
+    </div>
+  `;
+
+  container.innerHTML = '';
+  container.appendChild(node);
+  return node;
+}
+
 // Basic Typing Tests
 runner.describe('Basic Typing', () => {
   let fixture;
-  runner.beforeEach(() => fixture = new EditorFixture());
+  runner.beforeEach(() => fixture = new EditorFixture(createEditorNode()));
 
   runner.it('should insert single character', () => {
     fixture.press('a').once();
@@ -38,7 +66,7 @@ runner.describe('Backspace', () => {
   let fixture;
 
   runner.beforeEach(() => {
-    fixture = new EditorFixture();
+    fixture = new EditorFixture(createEditorNode());
   });
 
   runner.it('should delete single character', () => {
@@ -94,7 +122,7 @@ runner.describe('Enter Key', () => {
   let fixture;
 
   runner.beforeEach(() => {
-    fixture = new EditorFixture();
+    fixture = new EditorFixture(createEditorNode());
   });
 
   runner.it('should create new line', () => {
@@ -145,7 +173,7 @@ runner.describe('Complex Sequences', () => {
   let fixture;
 
   runner.beforeEach(() => {
-    fixture = new EditorFixture();
+    fixture = new EditorFixture(createEditorNode());
   });
 
   runner.it('should type, delete, and retype', () => {
@@ -215,7 +243,7 @@ runner.describe('Selection', () => {
   let fixture;
 
   runner.beforeEach(() => {
-    fixture = new EditorFixture();
+    fixture = new EditorFixture(createEditorNode());
   });
 
   runner.it('should create selection with Shift+ArrowRight', () => {
@@ -308,7 +336,7 @@ runner.describe('Cursor movement - varying line lengths', () => {
   let fixture;
 
   runner.beforeEach(() => {
-    fixture = new EditorFixture();
+    fixture = new EditorFixture(createEditorNode());
   });
 
   runner.it('should preserve column when moving from long to short line', () => {
@@ -428,7 +456,7 @@ runner.describe('Meta+Arrow navigation', () => {
   let fixture;
 
   runner.beforeEach(() => {
-    fixture = new EditorFixture();
+    fixture = new EditorFixture(createEditorNode());
   });
 
   runner.it('should move to end of line with Meta+Right', () => {
@@ -494,7 +522,7 @@ runner.describe('Shift+Meta+Arrow selection', () => {
   let fixture;
 
   runner.beforeEach(() => {
-    fixture = new EditorFixture();
+    fixture = new EditorFixture(createEditorNode());
   });
 
   runner.it('should select to end of line with Shift+Meta+Right', () => {
@@ -564,7 +592,7 @@ runner.describe('Multi-line selections', () => {
   let fixture;
 
   runner.beforeEach(() => {
-    fixture = new EditorFixture();
+    fixture = new EditorFixture(createEditorNode());
   });
 
   runner.it('should select 3 rows with start in middle, end in middle', () => {
@@ -779,7 +807,7 @@ runner.describe('Deleting selections', () => {
   let fixture;
 
   runner.beforeEach(() => {
-    fixture = new EditorFixture();
+    fixture = new EditorFixture(createEditorNode());
   });
 
   runner.it('should delete single line selection with Backspace', () => {
@@ -893,7 +921,7 @@ runner.describe('Replacing selections', () => {
   let fixture;
 
   runner.beforeEach(() => {
-    fixture = new EditorFixture();
+    fixture = new EditorFixture(createEditorNode());
   });
 
   runner.it('should replace single line selection with typed character', () => {
@@ -1018,7 +1046,7 @@ runner.describe('Regression: Selection.ordered and isForwardSelection', () => {
   let fixture;
 
   runner.beforeEach(() => {
-    fixture = new EditorFixture();
+    fixture = new EditorFixture(createEditorNode());
   });
 
   runner.it('should correctly identify forward selection when tail < head', () => {
@@ -1089,7 +1117,7 @@ runner.describe('Walkthrough feature - regression tests', () => {
   let fixture;
 
   runner.beforeEach(() => {
-    fixture = new EditorFixture();
+    fixture = new EditorFixture(createEditorNode());
   });
 
   runner.it('should demonstrate interleaved success and failure expects', () => {

--- a/test/walkthrough.js
+++ b/test/walkthrough.js
@@ -1,0 +1,347 @@
+// Utility function for escaping HTML
+function escapeHtml(text) {
+  const div = document.createElement('div');
+  div.textContent = text;
+  return div.innerHTML;
+}
+
+/**
+ * Walkthrough - Handles step recording and interactive walkthrough UI
+ */
+class Walkthrough {
+  constructor() {
+    this.steps = [];
+    this.currentTest = null;
+    this.currentStep = 0;
+    this.walkthroughHarness = null;
+  }
+
+  // Record a step (called by EditorTestHarness)
+  recordStep(description, metadata) {
+    this.steps.push({
+      description,
+      metadata
+    });
+  }
+
+  // Replay a step on a harness
+  replayStep(harness, stepIndex) {
+    const step = this.steps[stepIndex];
+    const meta = step.metadata;
+
+    if (meta.type === 'type') {
+      for (const char of meta.text) {
+        dispatchKey(harness.node, char);
+      }
+    } else if (meta.type === 'press') {
+      const count = meta.count || 1;
+      for (let i = 0; i < count; i++) {
+        dispatchKey(harness.node, meta.key, meta.modifiers);
+      }
+    }
+  }
+
+  // Open walkthrough UI for a test
+  open(suiteName, testIndex) {
+    const suite = runner.suites.find(s => s.name === suiteName);
+    if (!suite) return;
+
+    const test = suite.results[testIndex];
+    if (!test || !test.fixture || !test.fixture.walkthrough) return;
+
+    this.currentTest = test;
+    this.currentStep = 0;
+    this.steps = test.fixture.walkthrough.steps;
+
+    // Update panel header
+    document.getElementById('walkthrough-test-name').textContent = test.name;
+    document.getElementById('walkthrough-test-desc').textContent = test.description || '';
+
+    // Display test code with inline step markers
+    const codeView = document.getElementById('walkthrough-code');
+    const sourceLines = test.fnSource.split('\n');
+
+    // Map steps to source code lines by matching step descriptions
+    const lineToStep = new Map();
+    let stepIndex = 0;
+
+    sourceLines.forEach((line, idx) => {
+      if (stepIndex < this.steps.length) {
+        const step = this.steps[stepIndex];
+        if (line.includes(step.description.split('(')[0])) {
+          lineToStep.set(idx, stepIndex);
+          stepIndex++;
+        }
+      }
+    });
+
+    // Find error line if test failed
+    let errorLineIndex = -1;
+    if (test.status === 'fail' && test.error) {
+      const stackToUse = test.error.expectCallStack || test.error.stack;
+
+      if (stackToUse) {
+        const stackLines = stackToUse.split('\n');
+        for (const stackLine of stackLines) {
+          const match = stackLine.match(/<anonymous>:(\d+):(\d+)/);
+          if (match) {
+            const lineNum = parseInt(match[1]);
+            errorLineIndex = lineNum - 2;
+
+            if (errorLineIndex >= 0 && errorLineIndex < sourceLines.length) {
+              break;
+            }
+          }
+        }
+
+        if (errorLineIndex === -1 || errorLineIndex < 0 || errorLineIndex >= sourceLines.length) {
+          const errorMsg = test.error.message || '';
+          sourceLines.forEach((line, idx) => {
+            if (line.includes('expect(') && errorLineIndex === -1) {
+              errorLineIndex = idx;
+            }
+          });
+        }
+      }
+    }
+
+    // Find successful and failed expect lines using sequence numbers
+    const successLineIndices = new Set();
+    const failureLineIndices = new Set();
+
+    const expectLines = [];
+    sourceLines.forEach((line, idx) => {
+      if (line.includes('expect(') && !line.trim().startsWith('//')) {
+        expectLines.push(idx);
+      }
+    });
+
+    const expectResults = test.expectResults || [];
+
+    expectResults.forEach((result, i) => {
+      if (i < expectLines.length) {
+        const lineIdx = expectLines[i];
+        if (result.success) {
+          successLineIndices.add(lineIdx);
+        } else {
+          failureLineIndices.add(lineIdx);
+        }
+      }
+    });
+
+    // Store expect data for progressive revealing
+    this.currentTest.expectData = {
+      successLineIndices,
+      failureLineIndices,
+      lineToStep
+    };
+
+    // Render source with step markers (expects hidden initially)
+    this.renderCode();
+
+    // Create editor instance
+    const editorNode = document.getElementById('walkthrough-editor');
+    editorNode.className = 'wb no-select';
+    editorNode.innerHTML = `
+      <textarea class="wb-clipboard-bridge" aria-hidden="true"></textarea>
+      <div style="display: flex">
+        <div class="wb-gutter"></div>
+        <div class="wb-lines" style="flex: 1; overflow: hidden;"></div>
+      </div>
+      <div class="wb-status" style="display: flex; justify-content: space-between;">
+        <div class="wb-status-left" style="display: flex;">
+          <span class="wb-linecount"></span>
+        </div>
+        <div class="wb-status-right" style="display: flex;">
+          <span class="wb-coordinate"></span>
+          <span>|</span>
+          <span class="wb-indentation"></span>
+        </div>
+      </div>
+    `;
+
+    this.walkthroughHarness = FixtureFactory.forWalkthrough(editorNode);
+
+    // Copy steps from test fixture to walkthrough fixture
+    this.walkthroughHarness.walkthrough.steps = this.steps;
+
+    // Expose to window for console debugging
+    window.__walkthroughFixture = this.walkthroughHarness;
+
+    // Show panel and update display
+    document.getElementById('walkthrough-panel').classList.add('active');
+    this.updateDisplay();
+  }
+
+  close() {
+    document.getElementById('walkthrough-panel').classList.remove('active');
+    this.currentTest = null;
+    this.currentStep = 0;
+    this.walkthroughHarness = null;
+  }
+
+  renderCode() {
+    if (!this.currentTest) return;
+
+    const test = this.currentTest;
+    const { successLineIndices, failureLineIndices, lineToStep } = test.expectData || {};
+    if (!lineToStep) return;
+
+    const codeView = document.getElementById('walkthrough-code');
+    const sourceLines = test.fnSource.split('\n');
+
+    // Determine which expects should be revealed based on current step
+    const totalSteps = this.steps.length;
+    const isComplete = this.currentStep >= totalSteps;
+
+    let maxRevealedLine = -1;
+    if (this.currentStep > 0) {
+      for (const [lineIdx, stepNum] of lineToStep.entries()) {
+        if (stepNum < this.currentStep) {
+          maxRevealedLine = Math.max(maxRevealedLine, lineIdx);
+        }
+      }
+    }
+
+    const codeHtml = sourceLines.map((line, lineIndex) => {
+      const stepNum = lineToStep.get(lineIndex);
+      const isStepLine = stepNum !== undefined;
+      const isFailureLine = failureLineIndices?.has(lineIndex);
+      const isSuccessLine = successLineIndices?.has(lineIndex);
+
+      const shouldRevealExpect = isComplete || lineIndex <= maxRevealedLine;
+
+      let classes = 'code-line';
+      if (isFailureLine && shouldRevealExpect) classes += ' error-line';
+      if (isSuccessLine && !isFailureLine && shouldRevealExpect) classes += ' success-line';
+      if (isStepLine) classes += ' step-line';
+
+      const onclick = isStepLine ? `onclick="walkthrough.jumpToStep(${stepNum})"` : '';
+
+      let marker = '';
+      if (isStepLine) {
+        marker += `<span class="step-marker">${stepNum + 1}</span>`;
+      }
+      if (isFailureLine && shouldRevealExpect) {
+        marker += `<span class="error-marker">✗</span>`;
+      } else if (isSuccessLine && shouldRevealExpect) {
+        marker += `<span class="success-marker">✓</span>`;
+      }
+
+      return `<div class="${classes}" data-step="${stepNum ?? ''}" ${onclick}>${marker}${escapeHtml(line)}</div>`;
+    }).join('');
+
+    codeView.innerHTML = codeHtml;
+  }
+
+  stepNext() {
+    if (!this.currentTest || this.currentStep >= this.steps.length) return;
+
+    this.replayStep(this.walkthroughHarness, this.currentStep);
+    this.currentStep++;
+    this.updateDisplay();
+  }
+
+  stepPrev() {
+    if (!this.currentTest || this.currentStep <= 0) return;
+
+    // Reset editor and replay up to previous step
+    const editorNode = document.getElementById('walkthrough-editor');
+    editorNode.className = 'wb no-select';
+    editorNode.innerHTML = `
+      <textarea class="wb-clipboard-bridge" aria-hidden="true"></textarea>
+      <div style="display: flex">
+        <div class="wb-gutter"></div>
+        <div class="wb-lines" style="flex: 1; overflow: hidden;"></div>
+      </div>
+      <div class="wb-status" style="display: flex; justify-content: space-between;">
+        <div class="wb-status-left" style="display: flex;">
+          <span class="wb-linecount"></span>
+        </div>
+        <div class="wb-status-right" style="display: flex;">
+          <span class="wb-coordinate"></span>
+          <span>|</span>
+          <span class="wb-indentation"></span>
+        </div>
+      </div>
+    `;
+
+    this.walkthroughHarness = FixtureFactory.forWalkthrough(editorNode);
+    this.walkthroughHarness.walkthrough.steps = this.steps;
+    window.__walkthroughFixture = this.walkthroughHarness;
+
+    this.currentStep--;
+
+    for (let i = 0; i < this.currentStep; i++) {
+      this.replayStep(this.walkthroughHarness, i);
+    }
+
+    this.updateDisplay();
+  }
+
+  updateDisplay() {
+    if (!this.currentTest) return;
+
+    const totalSteps = this.steps.length;
+    const stepInfo = document.getElementById('step-info');
+
+    if (this.currentStep === 0) {
+      stepInfo.textContent = `Ready to start (${totalSteps} steps)`;
+    } else if (this.currentStep <= totalSteps) {
+      const step = this.steps[this.currentStep - 1];
+      stepInfo.textContent = `Step ${this.currentStep}/${totalSteps}: ${step.description}`;
+    }
+
+    document.getElementById('step-prev').disabled = this.currentStep === 0;
+    document.getElementById('step-next').disabled = this.currentStep >= totalSteps;
+
+    this.renderCode();
+
+    const stepLines = document.querySelectorAll('.step-line');
+    stepLines.forEach((lineEl) => {
+      const stepNum = parseInt(lineEl.dataset.step);
+      lineEl.classList.remove('current', 'completed');
+      if (stepNum < this.currentStep - 1) {
+        lineEl.classList.add('completed');
+      } else if (stepNum === this.currentStep - 1) {
+        lineEl.classList.add('current');
+      }
+    });
+  }
+
+  jumpToStep(targetStep) {
+    if (!this.currentTest) return;
+
+    const editorNode = document.getElementById('walkthrough-editor');
+    editorNode.className = 'wb no-select';
+    editorNode.innerHTML = `
+      <textarea class="wb-clipboard-bridge" aria-hidden="true"></textarea>
+      <div style="display: flex">
+        <div class="wb-gutter"></div>
+        <div class="wb-lines" style="flex: 1; overflow: hidden;"></div>
+      </div>
+      <div class="wb-status" style="display: flex; justify-content: space-between;">
+        <div class="wb-status-left" style="display: flex;">
+          <span class="wb-linecount"></span>
+        </div>
+        <div class="wb-status-right" style="display: flex;">
+          <span class="wb-coordinate"></span>
+          <span>|</span>
+          <span class="wb-indentation"></span>
+        </div>
+      </div>
+    `;
+
+    this.walkthroughHarness = FixtureFactory.forWalkthrough(editorNode);
+    this.walkthroughHarness.walkthrough.steps = this.steps;
+    window.__walkthroughFixture = this.walkthroughHarness;
+
+    this.currentStep = targetStep + 1;
+
+    for (let i = 0; i <= targetStep; i++) {
+      this.replayStep(this.walkthroughHarness, i);
+    }
+
+    this.updateDisplay();
+  }
+}


### PR DESCRIPTION
Claude led the development of a Interactive Walkthrough for Test Cases.

<img width="1457" height="514" alt="Screenshot 2025-10-04 at 4 33 44 AM" src="https://github.com/user-attachments/assets/ab4f27a2-79c2-4e0d-86e9-558c57cb6c80" />

Originally, I intended to have a static pane that shows the test spec next to a WarrenBuf editor where you can manually walk through the test spec and inspect for yourself what went wrong. I expected Claude would generate some decent HTML/CSS and I'd have to wire things up myself. Claude made great HTML/CSS, better than the average software engineer.

I was still skeptical of AI's capabilities. I then asked Claude to put a line seperator in the spec source code to indicate which step the test failed at. Claude ended up creating a back/forth stepper. I thought it was just a bunch of HTML/CSS that didn't do anything. To my surprise, the next stepper worked. That's good, but perhaps I am desensitized with how far things have gone. 

Then... the back stepper worked. Now I'm impressed and asked WTH?

This was for the simple test case where we type "A", so perhaps it was just a coinidence where the "back" step was just reverting the editor to the initial state. i.e. a red herring. 

I went to more complicated sequences and Claude implemented a time-travel mechanism. Perhaps this is even better a debugger. Granted, this is not how I would implement an undo/redo stack in WarrenBuf because there is too much overhead. However, it's worth studying Claude more on this topic in the future. 

I spent the majority of the time with this PR prompting Claude on how to provide highlighting for failed/succesful expects, which may be interweaved between guidance steps. This confused Claude alot. 

Along the way, Claude also came up with some brief summary of the user behaviors. "print("hello")" instead of the equivalent JavaScript "fixture.type("hello").once()". I was already intending on defining a human DSL that transpiles to the JavaScript test spec, so Claude is half a step of itself. I'll deal with this in a subsequent MR. 



